### PR TITLE
Fix worker initialization in dev mode

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -36,7 +36,8 @@ if (isMainThread) {
         for (let i = 0; i < numWorkers; i++) {
             const workerFeeds = rssFeeds.feeds.slice(i * feedsPerWorker, (i + 1) * feedsPerWorker);
             const worker = new Worker(__filename, {
-                workerData: { feeds: workerFeeds, filters: filters }
+                workerData: { feeds: workerFeeds, filters: filters },
+                execArgv: process.execArgv
             });
 
             worker.on('message', async (message: { type: string, story: Story }) => {


### PR DESCRIPTION
## Summary
- ensure worker threads inherit exec arguments from the parent

## Testing
- `npm run build` *(fails: Cannot find module 'discord.js' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6849d8923bd08333b1c08834284da7d9