### PR TITLE
Add Jest and initial unit tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+export default {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "build": "tsc",
     "start": "node app.js",
-    "dev": "nodemon"
+    "dev": "nodemon",
+    "test": "jest"
   },
   "author": "Shay DeWael",
   "license": "MIT",
@@ -27,6 +28,8 @@
   "devDependencies": {
     "@types/node": "^20.11.0",
     "nodemon": "^2.0.22",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.3.3"
   }

--- a/src/app.ts
+++ b/src/app.ts
@@ -18,7 +18,17 @@ const filters = ['zelda', 'a link to the past', 'ocarina of time', 'majora\'s ma
 
 const rssFeeds = JSON.parse(readFileSync(join(__dirname, 'rssFeeds.json'), 'utf8'));
 
-if (isMainThread) {
+export function getSourceFromUrl(url: string): string {
+    try {
+        const hostname = new URL(url).hostname;
+        return hostname.replace('www.', '').split('.')[0];
+    } catch (error) {
+        console.error('Error parsing URL:', error);
+        return 'Unknown Source';
+    }
+}
+
+if (isMainThread && process.env.NODE_ENV !== 'test') {
     const client = new Client({
         intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.MessageContent]
     });
@@ -58,16 +68,6 @@ if (isMainThread) {
         }
     }
 
-    function getSourceFromUrl(url: string): string {
-        try {
-            const hostname = new URL(url).hostname;
-            return hostname.replace('www.', '').split('.')[0];
-        } catch (error) {
-            console.error('Error parsing URL:', error);
-            return 'Unknown Source';
-        }
-    }
-    
     async function getImageUrlFromArticle(url: string): Promise<string | null> {
         const controller = new AbortController();
         const timeoutId = setTimeout(() => controller.abort(), 5000);

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -1,0 +1,12 @@
+import { getSourceFromUrl } from '../src/app.js';
+
+describe('getSourceFromUrl', () => {
+  it('returns domain for valid urls', () => {
+    expect(getSourceFromUrl('https://example.com/page')).toBe('example');
+    expect(getSourceFromUrl('http://www.google.com')).toBe('google');
+  });
+
+  it('returns Unknown Source for invalid urls', () => {
+    expect(getSourceFromUrl('not a url')).toBe('Unknown Source');
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest dev setup
- export `getSourceFromUrl` so it can be tested
- skip main execution during tests
- create Jest config and sample tests
- add Jest script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849dac7d82c8333ad1be6216ec867e8