### PR TITLE
Add slash commands for updates

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,9 @@
 export default {
   preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { useESM: true, tsconfig: 'tsconfig.json' }]
+  },
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1'
   }


### PR DESCRIPTION
## Summary
- add slash commands to start/stop game updates
- register commands on startup
- handle interactions instead of message content
- adjust jest config for ESM

## Testing
- `npm test --silent` *(fails: TS1343 import.meta)*

------
https://chatgpt.com/codex/tasks/task_e_6849df8ef9cc8333ba61844b1c908c91